### PR TITLE
Migrate GitHub actions from AdoptOpenJDK to Eclipse Temurin [HZ-4195]

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -22,10 +22,10 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Set up Java and credentials
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: 8
-        distribution: 'adopt'
+        distribution: 'temurin'
         server-id: ossrh
         server-username: MAVEN_USERNAME
         server-password: MAVEN_PASSWORD

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -13,10 +13,10 @@ jobs:
       - name: Get all the letters, words and paragraphs needed for the spell!
         uses: actions/checkout@v3
       - name: Prepare the cauldron and the wand!
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'adopt'
+          distribution: 'temurin'
           cache: 'maven'
       - name: Maven, now you do the magic! I enchant you the Bash way!
         run: |

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Apache Maven Central
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 8
-          distribution: 'adopt'
+          distribution: 'temurin'
           server-id: ossrh
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD


### PR DESCRIPTION
The `setup-java` [documentation highlights that AdoptOpenJDK no longer receives security updates](https://github.com/actions/setup-java#:~:text=NOTE%3A%20AdoptOpenJDK%20got%20moved%20to%20Eclipse%20Temurin), and instead the Eclipse Temurin JDK should be used.

Fixes [HZ-4195](https://hazelcast.atlassian.net/browse/HZ-4195)

[HZ-4195]: https://hazelcast.atlassian.net/browse/HZ-4195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ