### PR TITLE
Specify `maven-enforcer-plugin` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -248,6 +248,7 @@
                     </plugin>
                     <plugin>
                         <artifactId>maven-enforcer-plugin</artifactId>
+                        <version>3.4.1</version>
                         <executions>
                             <execution>
                                 <id>enforce-java</id>


### PR DESCRIPTION
During [the release](https://github.com/hazelcast/attribution-maven-plugin/actions/runs/9307432140/job/25618693477) a warning was logged:

```
Warning:  Some problems were encountered while building the effective model for com.hazelcast.maven:attribution-maven-plugin:maven-plugin:1.4.0
Warning:  'build.plugins.plugin.version' for org.apache.maven.plugins:maven-enforcer-plugin is missing. @ line 249, column 29
Warning:  
Warning:  It is highly recommended to fix these problems because they threaten the stability of your build.
Warning:  
Warning:  For this reason, future Maven versions might no longer support building such malformed projects.
```