### PR TITLE
Upgrade Maven version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
-        <mavenVersion>3.6.3</mavenVersion>
     </properties>
 
     <dependencies>
@@ -24,7 +23,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>${mavenVersion}</version>
+            <version>3.9.7</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Maven `3.6.3` is [end-of-life](https://maven.apache.org/docs/history.html#maven-3-6-x-and-before) and is vulnerable to a [CVE](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-26291).

The latest version should be used.