### PR TITLE
Revert "Bump org.apache.maven:maven-core from 3.9.7 to 3.9.8"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
-            <version>3.9.8</version>
+            <version>3.9.7</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
Reverts hazelcast/attribution-maven-plugin#97

This broke the PR builder