### PR TITLE
Use consistent `mvn` arguments

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -44,7 +44,7 @@ jobs:
         git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
         git push origin v${{ github.event.inputs.release-version }} main
       env:
-        MAVEN_OPTS: --batch-mode --no-transfer-progress --errors
+        MAVEN_ARGS: --batch-mode --no-transfer-progress --errors
         MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -35,15 +35,16 @@ jobs:
 
     - name: Do the Deployment and related stuff
       run: |
-        mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
+        mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
         git commit -am "Release ${{ github.event.inputs.release-version }}"
         git tag v${{ github.event.inputs.release-version }}
-        mvn clean install -B
-        mvn deploy -B -Prelease -DskipTests
-        mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
+        mvn clean install
+        mvn deploy -Prelease -DskipTests
+        mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
         git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
         git push origin v${{ github.event.inputs.release-version }} main
       env:
+        MAVEN_OPTS: --batch-mode --no-transfer-progress --errors
         MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -20,5 +20,7 @@ jobs:
           cache: 'maven'
       - name: Maven, now you do the magic! I enchant you the Bash way!
         run: |
-          mvn --batch-mode --update-snapshots install
-          mvn --batch-mode -Prun-its verify -DskipTests
+          mvn install
+          mvn -Prun-its verify -DskipTests
+        env:
+          MAVEN_OPTS: --batch-mode --no-transfer-progress --errors

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -23,4 +23,4 @@ jobs:
           mvn install
           mvn -Prun-its verify -DskipTests
         env:
-          MAVEN_OPTS: --batch-mode --no-transfer-progress --errors
+          MAVEN_ARGS: --batch-mode --no-transfer-progress --errors


### PR DESCRIPTION
Use the same options - e.g. `--no-transfer-progress` - for all commands.

Specifically - avoid filling the logs with `Downloaded from central` entries.