### PR TITLE
Migrate attribution-maven-plugin to new Central plugin [DI-643]

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -35,8 +35,6 @@ jobs:
 
     - name: Do the Deployment and related stuff
       run: |
-        MAVEN_ARGS="--batch-mode --no-transfer-progress"
-        export MAVEN_ARGS
         mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
         git commit -am "Release ${{ github.event.inputs.release-version }}"
         git tag v${{ github.event.inputs.release-version }}
@@ -49,3 +47,4 @@ jobs:
         MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
         MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+        MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -35,12 +35,14 @@ jobs:
 
     - name: Do the Deployment and related stuff
       run: |
-        mvn versions:set --batch-mode --no-transfer-progress -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
+        MAVEN_ARGS="--batch-mode --no-transfer-progress"
+        export MAVEN_ARGS
+        mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
         git commit -am "Release ${{ github.event.inputs.release-version }}"
         git tag v${{ github.event.inputs.release-version }}
-        mvn clean install --batch-mode --no-transfer-progress
-        mvn deploy --batch-mode --no-transfer-progress -Prelease -DskipTests
-        mvn versions:set --batch-mode --no-transfer-progress -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
+        mvn clean install
+        mvn deploy -Prelease -DskipTests
+        mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
         git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
         git push origin v${{ github.event.inputs.release-version }} main
       env:

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -41,7 +41,7 @@ jobs:
         git commit -am "Release ${{ github.event.inputs.release-version }}"
         git tag v${{ github.event.inputs.release-version }}
         mvn clean install
-        mvn deploy -Prelease -DskipTests
+        mvn deploy --activate-profiles release -DskipTests
         mvn versions:set -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
         git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
         git push origin v${{ github.event.inputs.release-version }} main

--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -35,12 +35,12 @@ jobs:
 
     - name: Do the Deployment and related stuff
       run: |
-        mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
+        mvn versions:set --batch-mode --no-transfer-progress -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.release-version }}
         git commit -am "Release ${{ github.event.inputs.release-version }}"
         git tag v${{ github.event.inputs.release-version }}
-        mvn clean install -B
-        mvn deploy -B -Prelease -DskipTests
-        mvn versions:set -B -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
+        mvn clean install --batch-mode --no-transfer-progress
+        mvn deploy --batch-mode --no-transfer-progress -Prelease -DskipTests
+        mvn versions:set --batch-mode --no-transfer-progress -DgenerateBackupPoms=false -DnewVersion=${{ github.event.inputs.next-snapshot-version }}
         git commit -am "Next version is ${{ github.event.inputs.next-snapshot-version }}"
         git push origin v${{ github.event.inputs.release-version }} main
       env:

--- a/.github/workflows/pr-builder.yaml
+++ b/.github/workflows/pr-builder.yaml
@@ -20,5 +20,7 @@ jobs:
           cache: 'maven'
       - name: Maven, now you do the magic! I enchant you the Bash way!
         run: |
-          mvn --batch-mode --update-snapshots install
-          mvn --batch-mode -Prun-its verify -DskipTests
+          mvn --update-snapshots install
+          mvn --activate-profiles run-its verify -DskipTests
+        env:
+          MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           PROJECT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
-            mvn --batch-mode -Prelease deploy
+            mvn --batch-mode --no-transfer-progress -Prelease deploy
           fi
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -30,9 +30,10 @@ jobs:
         run: |
           PROJECT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
-            mvn --batch-mode --no-transfer-progress --activate-profiles release deploy
+            mvn --activate-profiles release deploy
           fi
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.SONATYPE_OSS_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+          MAVEN_ARGS: --batch-mode --no-transfer-progress

--- a/.github/workflows/push-snapshots.yaml
+++ b/.github/workflows/push-snapshots.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           PROJECT_VERSION=$(mvn -q -Dexec.executable=echo -Dexec.args='${project.version}' --non-recursive exec:exec)
           if [[ "$PROJECT_VERSION" == *-SNAPSHOT ]]; then
-            mvn --batch-mode --no-transfer-progress -Prelease deploy
+            mvn --batch-mode --no-transfer-progress --activate-profiles release deploy
           fi
         env:
           MAVEN_USERNAME: ${{ secrets.SONATYPE_OSS_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.8.0</version>
+                        <version>0.9.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <!-- server id comes from settings.xml -->

--- a/pom.xml
+++ b/pom.xml
@@ -183,9 +183,14 @@
                         <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
+                            <!-- server id comes from settings.xml -->
                             <publishingServerId>ossrh</publishingServerId>
-                            <autoPublish>true</autoPublish>
+                            <!--
+                            wait until the artifacts are actually published automatically using 'autoPublish'.
+                            the default is `validated` which would then require manual publishing
+                            -->
                             <waitUntil>published</waitUntil>
+                            <autoPublish>true</autoPublish>
                             <checksums>required</checksums>
                             <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -144,10 +144,10 @@
 
     <developers>
         <developer>
-            <id>kwart</id>
-            <name>Josef Cacek</name>
-            <email>josef@hazelcast.com</email>
-            <organization>Hazelcast</organization>
+            <name>Hazelcast team</name>
+            <email>info@hazelcast.com</email>
+            <organization>Hazelcast, Inc.</organization>
+            <organizationUrl>https://hazelcast.com</organizationUrl>
         </developer>
     </developers>
 
@@ -157,17 +157,6 @@
         <url>http://github.com/hazelcast/attribution-maven-plugin/</url>
         <tag>HEAD</tag>
     </scm>
-
-    <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
-        </repository>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <repositories>
         <repository>
@@ -189,14 +178,16 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://ossrh-staging-api.central.sonatype.com/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>ossrh</publishingServerId>
+                            <autoPublish>true</autoPublish>
+                            <waitUntil>published</waitUntil>
+                            <checksums>required</checksums>
+                            <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots</centralSnapshotsUrl>
                         </configuration>
                     </plugin>
                     <plugin>


### PR DESCRIPTION
### Changes:

- Using https://central.sonatype.org/publish/publish-portal-maven
   - for both, `SNAPSHOT` and `release` deployments. The SNAPSHOT artifacts deploys directly and not via the staging feature
   - kept plugin under `release` profile as both deploys use the profile. It could have gone outside but left it
- Updated `<developer>` section from `mono` (previously Josef details)
- Changed `mvn` options to full name

### Testing:

#### Snapshot
- Ran [build ](https://github.com/hazelcast/attribution-maven-plugin/actions/runs/17946103555) on my branch
- Deployed `1.4.3-SNAPSHOT` successfully. Example [maven-metadata.xml](https://central.sonatype.com/repository/maven-snapshots/com/hazelcast/maven/attribution-maven-plugin/1.4.3-SNAPSHOT/maven-metadata.xml)

#### Release

Made temporary changes to allow deploy without actually publishing. However, I can make a fake release (1.4.3) if needed. Let me know!

- Ran with option `<autoPublish>false</autoPublish>` 
- Removed `git` commands from [do-release.yml]( https://github.com/hazelcast/attribution-maven-plugin/blob/main/.github/workflows/do-release.yml#L39) 
- Ran [build](https://github.com/hazelcast/attribution-maven-plugin/actions/runs/17945953585/job/51032302493) (release version 1.4.3)
- Reverted temp changes 
- Validated deployment available for publishing [here](https://central.sonatype.com/publishing/deployments)
- <img width="532" height="649" alt="image" src="https://github.com/user-attachments/assets/4c6bc57b-49db-43fd-94d3-a17e5dbe7f90" />

### Post tasks

- [ ] Release `1.4.3` from `main`
- [ ] Remove staged deployment plus also cleanup previous errored ones